### PR TITLE
移植魔改代码

### DIFF
--- a/cf_worker.js
+++ b/cf_worker.js
@@ -35,19 +35,23 @@ async function handleRequest(request) {
     console.log('X-Signature: ' + signature);
     console.log('X-Timestamp: ' + timestamp);
     console.log('ApiPath: ' + apiPath);
-    
+
+    // 构建请求头，确保所有原始头部都被正确传递
+    const headers = {};
+    for (const [key, value] of request.headers.entries()) {
+        headers[key] = value;
+    }
+    headers["X-AppId"] = appId;
+    headers["X-Signature"] = signature;
+    headers["X-Timestamp"] = timestamp.toString();
+    headers["X-Auth"] = "1";
+
     let response = await fetch(url, {
-        headers: {
-            ...request.headers,
-            "X-AppId": appId,
-            "X-Signature": signature,
-            "X-Timestamp": timestamp,
-            "X-Auth": "1",
-        },
+        headers: headers,
         body: request.body,
         method: request.method,
     });
-    response = new Response(await response.body, response);
+    response = new Response(response.body, response);
     response.headers.set('Access-Control-Allow-Origin', '*');
     return response;
 }


### PR DESCRIPTION
1、提取标题的时候，额外提取季度集数作为入参进行检索，提高准确度
2、增加智能匹配功能
3、增加自定义弹幕API
4、为官方API添加match接口支持
5、多季度播放的时候检索内容优化
6、将官方API和自定义API缓存区分化
7、添加播放时弹幕推理匹配的功能（基于dandanplay epid连续的特性）
8、合并搜索结果，同时展示官方API和自定义API搜索结果
9、修复worker端无法传递match请求头的问题

ps：我在你1.47版本的基础上把我魔改部分尽量移植过来，只能做到这样了